### PR TITLE
Compilation albums

### DIFF
--- a/src/lib/spotify/api.test.ts
+++ b/src/lib/spotify/api.test.ts
@@ -97,6 +97,15 @@ test("compilation", async () => {
   });
 });
 
+test("compilations", async () => {
+  const uri = "spotify:user:bxsl6x8wzzcbtbkwquzpcqz74";
+  const ps = await api.playlists(uri);
+  assert.lengthOf(ps, 72);
+
+  const cs = await api.compilations(uri);
+  assert.lengthOf(cs, 21);
+});
+
 test("playlist", async () => {
   const p = await api.playlist("spotify:playlist:0JOnan9Ym7vJ485NEfdu5E");
 

--- a/src/lib/spotify/api.test.ts
+++ b/src/lib/spotify/api.test.ts
@@ -58,15 +58,6 @@ test("albumTracks", async () => {
   });
 });
 
-test("compilations", async () => {
-  const uri = "spotify:user:bxsl6x8wzzcbtbkwquzpcqz74";
-  const ps = await api.playlists(uri);
-  assert.lengthOf(ps, 72);
-
-  const cs = await api.compilations(uri);
-  assert.lengthOf(cs, 21);
-});
-
 test("playlist", async () => {
   const p = await api.playlist("spotify:playlist:0JOnan9Ym7vJ485NEfdu5E");
 
@@ -108,7 +99,7 @@ test.skip("playlistAlbums", { timeout: 60000 }, async () => {
   console.log(JSON.stringify(as));
 });
 
-test.skip("playlistAlbums compilations", { timeout: 60000 }, async () => {
+test("playlistAlbums compilations", { timeout: 60000 }, async () => {
   const as = await api.playlistAlbums("spotify:playlist:1N8kQZjPWbMvkgxHOpSs8q");
   assert.lengthOf(as, 100);
 

--- a/src/lib/spotify/api.test.ts
+++ b/src/lib/spotify/api.test.ts
@@ -58,6 +58,45 @@ test("albumTracks", async () => {
   });
 });
 
+test("compilation", async () => {
+  // https://open.spotify.com/playlist/5zyp0d80VUrqV0diZWUM8U?si=789b8455026844de
+  const a = await api.compilation("spotify:playlist:5zyp0d80VUrqV0diZWUM8U");
+  assert.deepEqual(a, {
+    art: "https://image-cdn-ak.spotifycdn.com/image/ab67706c0000da84694fe565fdae754ddbd4f203",
+    artist: "Soulwax",
+    barcode: "",
+    compilation: true,
+    discs: 1,
+    genre: "",
+    src: "spotify:playlist:5zyp0d80VUrqV0diZWUM8U",
+    title: "2ManyMP3s",
+    tracks: a.tracks,
+    year: new Date(0),
+  });
+
+  assert.lengthOf(a.tracks, 49);
+
+  assert.deepEqual(a.tracks[0], {
+    album: "2ManyMP3s",
+    albumArtist: "Soulwax",
+    artist: "Peggy Gou",
+    bpm: 0,
+    comment:
+      "https://p.scdn.co/mp3-preview/058c7b9217aab439d95a06525c7a549f6af205cb?cid=adaaf209fb064dfab873a71817029e0d",
+    disc: 1,
+    genre: "",
+    isrc: "GBJX32275010",
+    key: "",
+    length: 410880,
+    mood: "",
+    src: "spotify:track:577TxxoJTaW1BxH6EUDlTS",
+    title: "I Go - Soulwax Remix",
+    track: 1,
+    type: "spotify",
+    year: new Date("2022-03-30T00:00:00.000Z"),
+  });
+});
+
 test("playlist", async () => {
   const p = await api.playlist("spotify:playlist:0JOnan9Ym7vJ485NEfdu5E");
 

--- a/src/lib/spotify/api.test.ts
+++ b/src/lib/spotify/api.test.ts
@@ -58,45 +58,6 @@ test("albumTracks", async () => {
   });
 });
 
-test("compilation", async () => {
-  // https://open.spotify.com/playlist/5zyp0d80VUrqV0diZWUM8U?si=789b8455026844de
-  const a = await api.compilation("spotify:playlist:5zyp0d80VUrqV0diZWUM8U");
-  assert.deepEqual(a, {
-    art: "https://image-cdn-ak.spotifycdn.com/image/ab67706c0000da84694fe565fdae754ddbd4f203",
-    artist: "Soulwax",
-    barcode: "",
-    compilation: true,
-    discs: 1,
-    genre: "",
-    src: "spotify:playlist:5zyp0d80VUrqV0diZWUM8U",
-    title: "2ManyMP3s",
-    tracks: a.tracks,
-    year: new Date(0),
-  });
-
-  assert.lengthOf(a.tracks, 49);
-
-  assert.deepEqual(a.tracks[0], {
-    album: "2ManyMP3s",
-    albumArtist: "Soulwax",
-    artist: "Peggy Gou",
-    bpm: 0,
-    comment:
-      "https://p.scdn.co/mp3-preview/058c7b9217aab439d95a06525c7a549f6af205cb?cid=adaaf209fb064dfab873a71817029e0d",
-    disc: 1,
-    genre: "",
-    isrc: "GBJX32275010",
-    key: "",
-    length: 410880,
-    mood: "",
-    src: "spotify:track:577TxxoJTaW1BxH6EUDlTS",
-    title: "I Go - Soulwax Remix",
-    track: 1,
-    type: "spotify",
-    year: new Date("2022-03-30T00:00:00.000Z"),
-  });
-});
-
 test("compilations", async () => {
   const uri = "spotify:user:bxsl6x8wzzcbtbkwquzpcqz74";
   const ps = await api.playlists(uri);
@@ -139,6 +100,48 @@ test("playlist", async () => {
     track: 6,
     type: "spotify",
     year: new Date("1971-09-24T00:00:00.000Z"),
+  });
+});
+
+test("playlistAlbums compilations", { timeout: 60000 }, async () => {
+  const as = await api.playlistAlbums("spotify:playlist:1N8kQZjPWbMvkgxHOpSs8q");
+  assert.lengthOf(as, 100);
+
+  // https://open.spotify.com/playlist/5zyp0d80VUrqV0diZWUM8U
+  const a = as[5];
+  assert.deepEqual(a, {
+    art: "https://image-cdn-ak.spotifycdn.com/image/ab67706c0000da84694fe565fdae754ddbd4f203",
+    artist: "Soulwax",
+    barcode: "",
+    compilation: true,
+    discs: 1,
+    genre: "",
+    src: "spotify:playlist:5zyp0d80VUrqV0diZWUM8U",
+    title: "2ManyMP3s",
+    tracks: a.tracks,
+    year: new Date(0),
+  });
+
+  assert.lengthOf(a.tracks, 49);
+
+  assert.deepEqual(a.tracks[0], {
+    album: "2ManyMP3s",
+    albumArtist: "Soulwax",
+    artist: "Peggy Gou",
+    bpm: 0,
+    comment:
+      "https://p.scdn.co/mp3-preview/058c7b9217aab439d95a06525c7a549f6af205cb?cid=adaaf209fb064dfab873a71817029e0d",
+    disc: 1,
+    genre: "",
+    isrc: "GBJX32275010",
+    key: "",
+    length: 410880,
+    mood: "",
+    src: "spotify:track:577TxxoJTaW1BxH6EUDlTS",
+    title: "I Go - Soulwax Remix",
+    track: 1,
+    type: "spotify",
+    year: new Date("2022-03-30T00:00:00.000Z"),
   });
 });
 

--- a/src/lib/spotify/api.test.ts
+++ b/src/lib/spotify/api.test.ts
@@ -103,7 +103,12 @@ test("playlist", async () => {
   });
 });
 
-test("playlistAlbums compilations", { timeout: 60000 }, async () => {
+test.skip("playlistAlbums", { timeout: 60000 }, async () => {
+  const as = await api.playlistAlbums("spotify:playlist:0JOnan9Ym7vJ485NEfdu5E");
+  console.log(JSON.stringify(as));
+});
+
+test.skip("playlistAlbums compilations", { timeout: 60000 }, async () => {
   const as = await api.playlistAlbums("spotify:playlist:1N8kQZjPWbMvkgxHOpSs8q");
   assert.lengthOf(as, 100);
 
@@ -183,10 +188,4 @@ test("trackAlbum", async () => {
     tracks: a.tracks,
     year: new Date("2018-01-17T00:00:00.000Z"),
   });
-});
-
-test.skip("tracksAlbum", { timeout: 60000 }, async () => {
-  const p = await api.playlist("spotify:playlist:0JOnan9Ym7vJ485NEfdu5E");
-  const as = await api.tracksAlbums(p.tracks);
-  console.log(JSON.stringify(as));
 });

--- a/src/lib/spotify/api.test.ts
+++ b/src/lib/spotify/api.test.ts
@@ -115,7 +115,7 @@ test("playlistAlbums compilations", { timeout: 60000 }, async () => {
     src: "spotify:playlist:5zyp0d80VUrqV0diZWUM8U",
     title: "2ManyMP3s",
     tracks: a.tracks,
-    year: new Date(0),
+    year: new Date("2022-08-19T15:56:57.000Z"),
   });
 
   assert.lengthOf(a.tracks, 49);
@@ -137,7 +137,7 @@ test("playlistAlbums compilations", { timeout: 60000 }, async () => {
     title: "I Go - Soulwax Remix",
     track: 1,
     type: "spotify",
-    year: new Date("2022-03-30T00:00:00.000Z"),
+    year: new Date("2022-08-19T15:56:57.000Z"),
   });
 });
 

--- a/src/lib/spotify/api.ts
+++ b/src/lib/spotify/api.ts
@@ -34,6 +34,25 @@ export const API = (token: () => Promise<string>) => {
     title: p.name,
   });
 
+  const _tracka = (a: Album, t: STrack): Track => ({
+    album: a.title,
+    albumArtist: a.artist,
+    artist: t.artists[0].name,
+    bpm: 0,
+    comment: t.preview_url || "",
+    disc: t.disc_number,
+    genre: a.genre,
+    isrc: (t as s.Track).external_ids?.isrc || "",
+    key: "",
+    length: t.duration_ms,
+    mood: "",
+    src: t.uri,
+    track: t.track_number,
+    title: t.name,
+    type: "spotify",
+    year: new Date((t as s.Track).album.release_date),
+  });
+
   const _track = (a: SAlbum, t: STrack): Track => ({
     album: a.name,
     albumArtist: a.artists[0].name,
@@ -69,9 +88,9 @@ export const API = (token: () => Promise<string>) => {
     return album;
   };
 
-  const compilation = async (uri: string): Promise<AlbumTracks> => {
+  const compilation = async (playlistUri: string): Promise<AlbumTracks> => {
     const a = await api();
-    const out = await a.playlists.getPlaylist(uri.split(":")[2]);
+    const out = await a.playlists.getPlaylist(playlistUri.split(":")[2]);
     const parts = out.name.split(" by ");
 
     const album: AlbumTracks = {
@@ -81,34 +100,14 @@ export const API = (token: () => Promise<string>) => {
       compilation: true,
       discs: 1, // FIXME
       genre: "",
-      src: uri,
+      src: playlistUri,
       title: parts[0],
       tracks: [],
       year: new Date(0),
     };
 
     album.tracks = out.tracks.items.map((pt) => {
-      const a = album;
-      const t = pt.track;
-
-      return {
-        album: a.title,
-        albumArtist: a.artist,
-        artist: t.artists[0].name,
-        bpm: 0,
-        comment: t.preview_url || "",
-        disc: t.disc_number,
-        genre: a.genre,
-        isrc: t.external_ids?.isrc || "",
-        key: "",
-        length: t.duration_ms,
-        mood: "",
-        src: t.uri,
-        track: t.track_number,
-        title: t.name,
-        type: "spotify",
-        year: new Date(t.album.release_date),
-      };
+      return _tracka(album, pt.track);
     });
 
     return album;
@@ -186,7 +185,6 @@ export const API = (token: () => Promise<string>) => {
   return {
     album,
     albumTracks,
-    compilations,
     playlist,
     playlists,
     playlistAlbums,

--- a/src/lib/spotify/api.ts
+++ b/src/lib/spotify/api.ts
@@ -69,6 +69,51 @@ export const API = (token: () => Promise<string>) => {
     return album;
   };
 
+  const compilation = async (uri: string): Promise<AlbumTracks> => {
+    const a = await api();
+    const out = await a.playlists.getPlaylist(uri.split(":")[2]);
+    const parts = out.name.split(" by ");
+
+    const album: AlbumTracks = {
+      art: out.images[0].url,
+      artist: parts[1],
+      barcode: "",
+      compilation: true,
+      discs: 1, // FIXME
+      genre: "",
+      src: uri,
+      title: parts[0],
+      tracks: [],
+      year: new Date(0),
+    };
+
+    album.tracks = out.tracks.items.map((pt) => {
+      const a = album;
+      const t = pt.track;
+
+      return {
+        album: a.title,
+        albumArtist: a.artist,
+        artist: t.artists[0].name,
+        bpm: 0,
+        comment: t.preview_url || "",
+        disc: t.disc_number,
+        genre: a.genre,
+        isrc: t.external_ids?.isrc || "",
+        key: "",
+        length: t.duration_ms,
+        mood: "",
+        src: t.uri,
+        track: t.track_number,
+        title: t.name,
+        type: "spotify",
+        year: new Date(t.album.release_date),
+      };
+    });
+
+    return album;
+  };
+
   const playlist = async (uri: string): Promise<PlaylistTracks> => {
     const a = await api();
     const out = await a.playlists.getPlaylist(uri.split(":")[2]);
@@ -112,6 +157,7 @@ export const API = (token: () => Promise<string>) => {
   return {
     album,
     albumTracks,
+    compilation,
     playlist,
     track,
     trackAlbum,

--- a/src/lib/spotify/api.ts
+++ b/src/lib/spotify/api.ts
@@ -22,7 +22,7 @@ export const API = (token: () => Promise<string>) => {
     const a = await api();
     const out = await a.albums.get(uri.split(":")[2]);
 
-    const album = to.album(out) as AlbumTracks;
+    const album = to.albumTracks(out);
     album.tracks = out.tracks.items.map((t) => to.track(out, t));
     return album;
   };
@@ -32,7 +32,7 @@ export const API = (token: () => Promise<string>) => {
     const out = await a.playlists.getPlaylist(playlistUri.split(":")[2]);
 
     const sa = to.compAlbum(out);
-    const album = to.album(sa) as AlbumTracks;
+    const album = to.albumTracks(sa);
     album.tracks = out.tracks.items.map((pt) => {
       return to.track(sa, pt.track);
     });
@@ -49,7 +49,7 @@ export const API = (token: () => Promise<string>) => {
     const a = await api();
     const out = await a.playlists.getPlaylist(uri.split(":")[2]);
 
-    const playlist = to.playlist(out) as PlaylistTracks;
+    const playlist = to.playlist(out);
     playlist.tracks = out.tracks.items.map((i) => to.track(i.track.album, i.track));
     return playlist;
   };

--- a/src/lib/spotify/api.ts
+++ b/src/lib/spotify/api.ts
@@ -114,6 +114,11 @@ export const API = (token: () => Promise<string>) => {
     return album;
   };
 
+  const compilations = async (userUri: string): Promise<s.SimplifiedPlaylist[]> => {
+    const ps = await playlists(userUri);
+    return ps.filter((p) => p.description.includes("JukeLab compilation"));
+  };
+
   const playlist = async (uri: string): Promise<PlaylistTracks> => {
     const a = await api();
     const out = await a.playlists.getPlaylist(uri.split(":")[2]);
@@ -121,6 +126,23 @@ export const API = (token: () => Promise<string>) => {
     const playlist = _playlist(out) as PlaylistTracks;
     playlist.tracks = out.tracks.items.map((i) => _track(i.track.album, i.track));
     return playlist;
+  };
+
+  const playlists = async (userUri: string): Promise<s.SimplifiedPlaylist[]> => {
+    const a = await api();
+
+    a.playlists.getUsersPlaylists(userUri.split(":")[2]);
+    let ps: s.SimplifiedPlaylist[] = [];
+    let offset = 0;
+    let total = 1;
+    while (offset < total) {
+      const out = await a.playlists.getUsersPlaylists(userUri.split(":")[2]);
+      total = out.total;
+      offset += out.limit;
+      ps.push(...out.items);
+    }
+
+    return ps;
   };
 
   const track = async (uri: string) => {
@@ -158,7 +180,9 @@ export const API = (token: () => Promise<string>) => {
     album,
     albumTracks,
     compilation,
+    compilations,
     playlist,
+    playlists,
     track,
     trackAlbum,
     tracksAlbums,

--- a/src/lib/spotify/to.ts
+++ b/src/lib/spotify/to.ts
@@ -1,4 +1,4 @@
-import type { Album, Playlist, Track } from "$lib/types/music";
+import type { Album, AlbumTracks, PlaylistTracks, Track } from "$lib/types/music";
 import * as s from "@spotify/web-api-ts-sdk";
 
 type SAlbum = s.Album | s.SimplifiedAlbum;
@@ -15,6 +15,12 @@ export const album = (a: SAlbum): Album => ({
   title: a.name,
   year: new Date(a.release_date),
 });
+
+export const albumTracks = (a: SAlbum): AlbumTracks => {
+  const al = album(a) as AlbumTracks;
+  al.tracks = [];
+  return al;
+};
 
 export const compAlbum = (p: s.Playlist): SAlbum => {
   const parts = p.name.split(" by ");
@@ -59,13 +65,14 @@ export const compAlbum = (p: s.Playlist): SAlbum => {
   };
 };
 
-export const playlist = (p: s.Playlist): Playlist => ({
+export const playlist = (p: s.Playlist): PlaylistTracks => ({
   art: p.images[0].url,
   id: p.snapshot_id,
   comment: p.description,
   owner: p.owner.display_name,
   src: p.uri,
   title: p.name,
+  tracks: [],
 });
 
 export const track = (a: SAlbum, t: STrack): Track => ({

--- a/src/lib/spotify/to.ts
+++ b/src/lib/spotify/to.ts
@@ -1,0 +1,88 @@
+import type { Album, Playlist, Track } from "$lib/types/music";
+import * as s from "@spotify/web-api-ts-sdk";
+
+type SAlbum = s.Album | s.SimplifiedAlbum;
+type STrack = s.Track | s.SimplifiedTrack;
+
+export const album = (a: SAlbum): Album => ({
+  art: a.images.at(0)?.url || "",
+  artist: a.artists[0].name,
+  barcode: a.external_ids.upc,
+  compilation: a.album_type == "compilation",
+  discs: 1, // FIXME
+  genre: a.genres[0] || "",
+  src: a.uri,
+  title: a.name,
+  year: new Date(a.release_date),
+});
+
+export const compAlbum = (p: s.Playlist): SAlbum => {
+  const parts = p.name.split(" by ");
+
+  return {
+    album_group: "",
+    artists: [
+      {
+        external_urls: {
+          spotify: "",
+        },
+        href: "",
+        id: "",
+        name: parts[1],
+        type: "",
+        uri: "",
+      },
+    ],
+    album_type: "compilation",
+    available_markets: [],
+    copyrights: [],
+    external_ids: {
+      upc: "",
+      isrc: "",
+      ean: "",
+    },
+    external_urls: {
+      spotify: "",
+    },
+    genres: [],
+    href: "",
+    id: "",
+    images: p.images,
+    label: "",
+    name: parts[0],
+    popularity: 0,
+    release_date: p.tracks.items[0].added_at,
+    release_date_precision: "",
+    total_tracks: 0,
+    type: "",
+    uri: p.uri,
+  };
+};
+
+export const playlist = (p: s.Playlist): Playlist => ({
+  art: p.images[0].url,
+  id: p.snapshot_id,
+  comment: p.description,
+  owner: p.owner.display_name,
+  src: p.uri,
+  title: p.name,
+});
+
+export const track = (a: SAlbum, t: STrack): Track => ({
+  album: a.name,
+  albumArtist: a.artists[0].name,
+  artist: t.artists[0].name,
+  bpm: 0,
+  comment: t.preview_url || "",
+  disc: t.disc_number,
+  genre: a.genres?.length > 0 ? a.genres[0] : "",
+  isrc: (t as s.Track).external_ids?.isrc || "",
+  key: "",
+  length: t.duration_ms,
+  mood: "",
+  src: t.uri,
+  track: t.track_number,
+  title: t.name,
+  type: "spotify",
+  year: new Date(a.release_date),
+});

--- a/src/routes/spotify/jukebox/playlist.svelte.ts
+++ b/src/routes/spotify/jukebox/playlist.svelte.ts
@@ -83,7 +83,7 @@ export const Playlist = () => {
         .filter((k) => k.startsWith(`${src}:`))
         .forEach((k) => localStorage.removeItem(k));
 
-      await api.tracksAlbums(playlist.tracks, (a) => {
+      await api.playlistAlbums(src, (a) => {
         const n = albums.push(a);
         progress.value = n;
         if (n == 1) {


### PR DESCRIPTION
Add support for custom albums and compilations via playlists that follow a convention to be modeled as an album. The convention is:

- Playlist name is "Album Name by Artist Name", e.g. "2ManyMP3s by Soulwax"
- Playlist description is "JukeLab compilation TrackID", e.g.  "JukeLab compilation 577TxxoJTaW1BxH6EUDlTS"

Then a jukebox playlist that includes `spotify:track:TrackID` (e.g. `spotify:track:577TxxoJTaW1BxH6EUDlTS`) will get the playlist album, artist name, artwork and list of tracks .

With:

- Find all compilation playlists for a user
- Convert a compilation playlist to an album
- Track to Album uses a compilation if it matches

Updates #33 