### PR TITLE
Drop common suffixes from album and track names

### DIFF
--- a/src/lib/recordutil.test.ts
+++ b/src/lib/recordutil.test.ts
@@ -1,0 +1,45 @@
+import { assert, test } from "vitest";
+import { normalizeAlbumTitle, normalizeTrackTitles } from "./recordutil";
+
+test("normalizeAlbumTitle", async () => {
+  const cases = [
+    ["Foobar", "Foobar"],
+    ["Foobar (deluxe)", "Foobar"],
+    ["Foobar (Deluxe)", "Foobar"],
+    ["Foobar [Deluxe]", "Foobar"],
+    ["Foobar [super deluxe]", "Foobar"],
+    ["Foobar baz z [20th Anniversary Super Foo]", "Foobar baz z"],
+  ];
+
+  cases.forEach(([title, expected]) => {
+    assert.equal(normalizeAlbumTitle(title), expected);
+  });
+});
+
+test("normalizeTrackTitles", async () => {
+  interface testCase {
+    titles: string[];
+    want?: string[]; // empty if no change
+  }
+  const cases: testCase[] = [
+    { titles: [] },
+    { titles: ["A"] },
+    { titles: ["A", "B", "C"] },
+    { titles: ["A - 2024 Remix", "B - 2024 Remix"], want: ["A", "B"] },
+    { titles: ["A - x1", "B - x1", "C"], want: ["A", "B", "C"] },
+    {
+      titles: ["A foo bar - 2023 Remaster", "B x y - 2023 Remaster", "C"],
+      want: ["A foo bar", "B x y", "C"],
+    },
+  ];
+
+  cases.forEach(({ titles, want }) => {
+    const [got, ok] = normalizeTrackTitles(titles);
+    if (want) {
+      assert.isTrue(ok);
+      assert.deepEqual(got, want);
+    } else {
+      assert.isFalse(ok);
+    }
+  });
+});

--- a/src/lib/recordutil.ts
+++ b/src/lib/recordutil.ts
@@ -1,0 +1,21 @@
+export const normalizeAlbumTitle = (title: string) => {
+  const titleRe = /\s+[([].*(deluxe|remaster|expanded|anniversary).*[)\]]$/i;
+  const titleMatch = title.match(titleRe);
+  if (titleMatch && titleMatch[0]) {
+    return title.replace(titleRe, "");
+  }
+  return title;
+};
+
+export const normalizeTrackTitles = (titles: string[]): [string[], boolean] => {
+  if (!titles || titles.length === 0) {
+    return [titles, false];
+  }
+
+  const suffixRe = /\s-\s[\w\d\s]+$/;
+  const suffixMatch = titles[0].match(suffixRe);
+  if (!suffixMatch || !suffixMatch[0]) {
+    return [titles, false];
+  }
+  return [titles.map((t) => t.replace(suffixRe, "")), true];
+};

--- a/src/routes/spotify/playlist.svelte.ts
+++ b/src/routes/spotify/playlist.svelte.ts
@@ -128,6 +128,21 @@ export const Playlist = () => {
       return v;
     });
 
+    albums.forEach((a) => {
+      const suffixRe = /\s-\s[\w\d\s]+$/;
+      if (!a.tracks) {
+        return;
+      }
+      const suffixMatch = a.tracks[0].title.match(suffixRe);
+      const suffix = suffixMatch ? suffixMatch[0] : null;
+      if (!suffix) {
+        return;
+      }
+      a.tracks.forEach((t) => {
+        t.title = t.title.replace(suffixRe, "");
+      });
+    });
+
     // update storage
     playlists = s.get("playlists", defaults["playlists"]);
     const n = playlists.findIndex((p) => p[1] == src);

--- a/src/routes/spotify/playlist.svelte.ts
+++ b/src/routes/spotify/playlist.svelte.ts
@@ -129,13 +129,18 @@ export const Playlist = () => {
     });
 
     albums.forEach((a) => {
-      const suffixRe = /\s-\s[\w\d\s]+$/;
+      const titleRe = /\s+[([].*(deluxe|remaster|expanded|anniversary).*[)\]]$/i;
+      const titleMatch = a.title.match(titleRe);
+      if (titleMatch && titleMatch[0]) {
+        a.title = a.title.replace(titleRe, "");
+      }
+
       if (!a.tracks) {
         return;
       }
+      const suffixRe = /\s-\s[\w\d\s]+$/;
       const suffixMatch = a.tracks[0].title.match(suffixRe);
-      const suffix = suffixMatch ? suffixMatch[0] : null;
-      if (!suffix) {
+      if (!suffixMatch || !suffixMatch[0]) {
         return;
       }
       a.tracks.forEach((t) => {

--- a/src/routes/spotify/playlist.svelte.ts
+++ b/src/routes/spotify/playlist.svelte.ts
@@ -39,12 +39,12 @@ export const Playlist = () => {
   let history = $state<Src[]>([]);
   let playlist = $state(PlaylistTracks);
   let playlists: string[][] = $state([]);
-  let progress = $state({ max: 0, value: 0 });
+  const progress = $state({ max: 0, value: 0 });
   let queue = $state<Src[]>([]);
   let shuffle = $state<Src[]>([]);
   let track = $state(Track);
 
-  let playing = $derived.by(() => {
+  const playing = $derived.by(() => {
     const an = albums.indexOf(album);
     const tn = album.tracks.indexOf(track);
     return tn >= 0 ? `${pad(an)}${pad(tn + 1)}` : "____";
@@ -120,7 +120,7 @@ export const Playlist = () => {
     }
 
     // parse text into dates
-    var re = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/; // startswith: 2015-04-29T22:06:55
+    const re = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/; // startswith: 2015-04-29T22:06:55
     albums = JSON.parse(text, (k, v) => {
       if (typeof v == "string" && re.test(v)) {
         return new Date(v);
@@ -177,7 +177,7 @@ export const Playlist = () => {
     else if (key == "shuffle") l = shuffle;
     else return;
 
-    var i = l.indexOf(src);
+    const i = l.indexOf(src);
     if (i == -1) return;
 
     if (delta === -Infinity) {

--- a/src/routes/spotify/playlist.svelte.ts
+++ b/src/routes/spotify/playlist.svelte.ts
@@ -1,4 +1,5 @@
 import { href } from "$lib/href";
+import { normalizeAlbumTitle, normalizeTrackTitles } from "$lib/recordutil";
 import { API } from "$lib/spotify/api";
 import * as s from "$lib/storage";
 import { pad } from "$lib/string";
@@ -129,23 +130,11 @@ export const Playlist = () => {
     });
 
     albums.forEach((a) => {
-      const titleRe = /\s+[([].*(deluxe|remaster|expanded|anniversary).*[)\]]$/i;
-      const titleMatch = a.title.match(titleRe);
-      if (titleMatch && titleMatch[0]) {
-        a.title = a.title.replace(titleRe, "");
+      a.title = normalizeAlbumTitle(a.title);
+      const [newTitles, ok] = normalizeTrackTitles(a.tracks.map((t) => t.title));
+      if (ok) {
+        newTitles.forEach((t, i) => (a.tracks[i].title = t));
       }
-
-      if (!a.tracks) {
-        return;
-      }
-      const suffixRe = /\s-\s[\w\d\s]+$/;
-      const suffixMatch = a.tracks[0].title.match(suffixRe);
-      if (!suffixMatch || !suffixMatch[0]) {
-        return;
-      }
-      a.tracks.forEach((t) => {
-        t.title = t.title.replace(suffixRe, "");
-      });
     });
 
     // update storage


### PR DESCRIPTION
Just some heuristics dropping a suffix starting with " - " from track names, when they match the first track's.

Some examples from 101:

- Electric Warrior [Expanded & Remastered]: Dropped ` - 2003 Remaster`
- The Rise and Fall of Ziggy Stardust and the Spiders from Mars (2012 Remaster): Dropped ` - 2012 Remaster`
- Ramones (2017 Remaster): Dropped ` - 2016 Remaster`
- Body Talk: Dropped ` - Radio Edit`
